### PR TITLE
 Increase timeout to 120 seconds

### DIFF
--- a/baichat_py/__init__.py
+++ b/baichat_py/__init__.py
@@ -52,7 +52,7 @@ class Completion:
             {"prompt": prompt, "options": {"parentMessageId": Completion.last_msg_id}}
         )
 
-        response = requests.post("https://chatbot.theb.ai/api/chat-process", headers=headers, data=payload, impersonate="chrome101", content_callback=Completion.handle_stream_response, proxies=proxies)
+        response = requests.post("https://chatbot.theb.ai/api/chat-process", headers=headers, data=payload, impersonate="chrome101", content_callback=Completion.handle_stream_response, proxies=proxies,timeout=120)
 
         if response.status_code != 200:
             raise CompletionError()


### PR DESCRIPTION
This pull request increases the timeout for the API request to 120 seconds in order to handle potential delays or slower response times. 

Default timeout was set to a shorter duration, which could result in premature termination of the request if it took longer than expected. By specifying the timeout value of 120 seconds, the request will now wait for a maximum of two minutes before considering it as timed out.